### PR TITLE
Added testing CI and compliance to Python >=3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build and Test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.10']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -e .
+      - name: Test with pytest
+        run: |
+          python3 -m pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
-    "pyaniml==1.0.2",
+    "pyAnIML==1.0.2",
     "seaborn",
     "scipy",
     "pytest>=7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
-    "pyaniml==1.0.1",
+    "pyaniml==1.0.2",
     "seaborn",
     "scipy",
     "pytest>=7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "SAS-tools"
 version = "0.0"
 description = "SAS-tools contains useful functions and classes for working with SAS data."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 license = {file = "LICENSE"}
 authors = [
     {name = "Torsten Giess", email = "torsten.giess@ibtb.uni-stuttgart.de"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pyaniml",
     "seaborn",
     "scipy",
+    "pytest>=7.2.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
-    "pyaniml",
+    "pyaniml==1.0.1",
     "seaborn",
     "scipy",
     "pytest>=7.2.0"

--- a/sastools/analyzer/curvefitting.py
+++ b/sastools/analyzer/curvefitting.py
@@ -6,6 +6,7 @@ import json
 import random
 
 from pathlib import Path
+from typing import Tuple, Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -37,6 +38,7 @@ class CurveFitting:
             path_plots (Path): Path to where plots are to be saved.
             path_fitting_data (Path): Path to where fitting data is to be saved.
         """
+        
         self.exp_data = experimental_data
         self.x = self.exp_data.iloc[:, 0].values.tolist()
         self.y = self.exp_data.iloc[:, 1].values.tolist()
@@ -44,7 +46,7 @@ class CurveFitting:
         self.path_plots = path_plots
         self.path_fitting_data = path_fitting_data
 
-    def _pack_data_into_dict(self) -> dict:
+    def _pack_data_into_dict(self) -> Dict:
         # Stores the data in a dictionary
         data_dict = {"data": {"x": self.x, "y": self.y}}
         return data_dict
@@ -63,7 +65,7 @@ class CurveFitting:
         )
 
     def find_peaks_cwt(
-        self, peak_widths: tuple = (20,), cutoff_amplitude: float = None
+        self, peak_widths: Tuple = (20,), cutoff_amplitude: Optional[float] = None
     ) -> None:
         """Find peaks using the `find_peaks_cwt` method from signal.
         Prints number of found peaks. Figure with positions of found
@@ -108,7 +110,7 @@ class CurveFitting:
         )
 
     def set_specifications_manually(
-        self, number_of_models: int, model_specifications: dict
+        self, number_of_models: int, model_specifications: Dict
     ) -> None:
         """Manually sets the specifications for the individual model
         used for the fitting procedure. Stores the generated
@@ -176,7 +178,7 @@ class CurveFitting:
         ) as outfile:
             outfile.write(json_models_dict)
 
-    def generate_model(self, speci: dict) -> tuple:
+    def generate_model(self, speci: Dict) -> tuple:
         """Generates a composite model and corresponding parameters
         based on the provided specifications using the `model` class
         of the python library `lmfit`.

--- a/sastools/analyzer/llcphase.py
+++ b/sastools/analyzer/llcphase.py
@@ -1,6 +1,7 @@
 """ABC defining properties of different LLC phases."""
 
 from abc import ABC, abstractmethod
+from typing import List, Tuple, Dict
 
 from sastools.analyzer.enums import LLCPhases, LLCSpaceGroups
 
@@ -9,7 +10,7 @@ class LLCPhase(ABC):
     """ABC defining the properties of an LLC Phase."""
 
     @abstractmethod
-    def calculate_lattice_parameters(self, d_meas: list[float]):
+    def calculate_lattice_parameters(self, d_meas: List[float]):
         ...
 
     @property
@@ -24,15 +25,15 @@ class LLCPhase(ABC):
 
     @property
     @abstractmethod
-    def miller_indices(self) -> tuple[list[int], list[int], list[int]]:
+    def miller_indices(self) -> Tuple[List[int], List[int], List[int]]:
         ...
 
     @property
     @abstractmethod
-    def lattice_parameters(self) -> list[float]:
+    def lattice_parameters(self) -> List[float]:
         ...
 
     @property
     @abstractmethod
-    def phase_information(self) -> dict:
+    def phase_information(self) -> Dict:
         ...

--- a/sastools/analyzer/llcphases.py
+++ b/sastools/analyzer/llcphases.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from typing import List, Tuple, Dict
+
 from sastools.analyzer.enums import LLCPhases, LLCSpaceGroups, LLCMillerIndices
 from sastools.analyzer.llcphase import LLCPhase
 
@@ -26,13 +28,13 @@ class HexagonalPhase(LLCPhase):
         return a_H1
 
     def calculate_lattice_parameters(
-        self, d_meas: list[float], phase: LLCPhases = LLCPhases.H1
+        self, d_meas: List[float], phase: LLCPhases = LLCPhases.H1
     ) -> None:
         """Calculate lattice parameters of hexagonal phase using a list
         of measured lattice plane distances `d_meas`.
 
         Args:
-            d_meas (list[float]): Measured lattice plane distances.
+            d_meas (List[float]): Measured lattice plane distances.
             phase (LLCPhases, optional): The hexagonal phase of the system. Defaults to LLCPhases.H1.
 
         Raises:
@@ -43,7 +45,7 @@ class HexagonalPhase(LLCPhase):
                 f"Chosen LLC phase '{phase}' is not (yet) supported."
             )
         self._exact_phase = phase
-        for i, j in enumerate(d_meas):
+        for i, _ in enumerate(d_meas):
             a_i = self._calculate_a_H1(
                 d_meas[i], self.miller_indices[0][i], self.miller_indices[1][i]
             )
@@ -64,18 +66,18 @@ class HexagonalPhase(LLCPhase):
         return self._space_group
 
     @property
-    def miller_indices(self) -> tuple[list[int], list[int], list[int]]:
+    def miller_indices(self) -> Tuple[List[int], List[int], List[int]]:
         """Get miller indices of hexagonal phase."""
         self._miller_indices = LLCMillerIndices[self._space_group.name].value
         return self._miller_indices
 
     @property
-    def lattice_parameters(self) -> list[float]:
+    def lattice_parameters(self) -> List[float]:
         """Get lattice parameters of hexagonal phase."""
         return self._lattice_parameters
 
     @property
-    def phase_information(self) -> dict:
+    def phase_information(self) -> Dict:
         """Get full phase information of hexagonal phase."""
         self._phase_information = dict(
             phase=self.exact_phase.value,
@@ -107,7 +109,7 @@ class CubicPhase(LLCPhase):
 
     def calculate_lattice_parameters(
         self,
-        d_meas: list[float],
+        d_meas: List[float],
         phase: LLCPhases = LLCPhases.V1,
         space_group: LLCSpaceGroups = LLCSpaceGroups.IA3D,
     ) -> None:
@@ -115,7 +117,7 @@ class CubicPhase(LLCPhase):
         measured lattice plane distances `d_meas`.
 
         Args:
-            d_meas (list[float]): Measured lattice plane distances.
+            d_meas (List[float]): Measured lattice plane distances.
             phase (LLCPhases, optional): The cubic phase of the system. Defaults to LLCPhases.V1.
             space_group (LLCSpaceGroups, optional): The space group corresponding to the cubic phase. Defaults to LLCSpaceGroups.IA3D.
 
@@ -137,13 +139,13 @@ class CubicPhase(LLCPhase):
             )
             self._lattice_parameters.append(a_i)
 
-    def calculate_d_reciprocal(self, peak_center: list[float]) -> None:
+    def calculate_d_reciprocal(self, peak_center: List[float]) -> None:
         """Calculate the reciprocal lattice plane distances
         `d_reciprocal` from the `peak_centers` determined through
         lorentzian fitting.
 
         Args:
-            peak_center (list[float]): Peak centers determined by lorentzian fitting for the cubic phase.
+            peak_center (List[float]): Peak centers determined by lorentzian fitting for the cubic phase.
         """
         self._d_reciprocal = [peak / (2 * np.pi) for peak in peak_center]
 
@@ -180,7 +182,7 @@ class CubicPhase(LLCPhase):
         self._space_group = space_group
 
     @property
-    def miller_indices(self) -> tuple[list[int], list[int], list[int]]:
+    def miller_indices(self) -> Tuple[List[int], List[int], List[int]]:
         """Get miller indices of cubic phase."""
         if self.space_group is None:
             raise ValueError("space_group property has to be provided first.")
@@ -188,12 +190,12 @@ class CubicPhase(LLCPhase):
         return self._miller_indices
 
     @property
-    def lattice_parameters(self) -> list[float]:
+    def lattice_parameters(self) -> List[float]:
         """Get lattice parameters of cubic phase."""
         return self._lattice_parameters
 
     @property
-    def phase_information(self) -> dict:
+    def phase_information(self) -> Dict:
         """Get full phase information of cubic phase."""
         self._phase_information = dict(
             phase=self.exact_phase.value,
@@ -202,12 +204,12 @@ class CubicPhase(LLCPhase):
         return self._phase_information
 
     @property
-    def d_reciprocal(self) -> list[float]:
+    def d_reciprocal(self) -> List[float]:
         """Get reciprocal lattice plane distances of cubic phase."""
         return self._d_reciprocal
 
     @property
-    def sqrt_miller(self) -> list[int]:
+    def sqrt_miller(self) -> List[int]:
         """Get square roots of miller indices of cubic phase."""
         return self._sqrt_miller
 
@@ -226,13 +228,13 @@ class LamellarPhase(LLCPhase):
         return "Lamellar LLC Phase"
 
     def calculate_lattice_parameters(
-        self, d_meas: list[float], phase: LLCPhases = LLCPhases.LA
+        self, d_meas: List[float], phase: LLCPhases = LLCPhases.LA
     ) -> None:
         """Calculate lattice parameters of lamellar phase using a list
         of measured lattice plane distances `d_meas`.
 
         Args:
-            d_meas (list[float]): Measured lattice plane distances.
+            d_meas (List[float]): Measured lattice plane distances.
             phase (LLCPhases, optional): The lamellar phase of the system. Defaults to LLCPhases.LA.
 
         Raises:
@@ -265,12 +267,12 @@ class LamellarPhase(LLCPhase):
         return self._miller_indices
 
     @property
-    def lattice_parameters(self) -> list[float]:
+    def lattice_parameters(self) -> List[float]:
         """Get lattice parameters of lamellar phase."""
         return self._lattice_parameters
 
     @property
-    def phase_information(self) -> dict:
+    def phase_information(self) -> Dict:
         """Get full phase information of lamellar phase."""
         self._phase_information = dict(
             phase=self.exact_phase.value,
@@ -293,13 +295,13 @@ class IndeterminatePhase(LLCPhase):
         return "Indeterminate LLC Phase"
 
     def calculate_lattice_parameters(
-        self, d_meas: list[float], phase: LLCPhases = LLCPhases.INDETERMINATE
+        self, d_meas: List[float], phase: LLCPhases = LLCPhases.INDETERMINATE
     ) -> None:
         """Do not use this method! Indeterminate phases have no lattice
         parameters.
 
         Args:
-            d_meas (list[float]): Measured lattice plane distances.
+            d_meas (List[float]): Measured lattice plane distances.
             phase (LLCPhases, optional): Indeterminate phase. Defaults to LLCPhases.INDETERMINATE.
 
         Raises:
@@ -330,7 +332,7 @@ class IndeterminatePhase(LLCPhase):
         return self._lattice_parameters
 
     @property
-    def phase_information(self) -> dict:
+    def phase_information(self) -> Dict:
         """Get full phase information of indeterminate phase."""
         self._phase_information = dict(
             phase=self.exact_phase.value,

--- a/sastools/analyzer/saxsanalyzers.py
+++ b/sastools/analyzer/saxsanalyzers.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from typing import List, Tuple, Dict, Optional
+
 from sastools.analyzer.enums import SAXSStandards
 from sastools.analyzer.llcphase import LLCPhase
 from sastools.analyzer.llcphases import (
@@ -18,7 +20,9 @@ class PrepareStandard:
     """
 
     def __init__(
-        self, standard: SAXSStandards = None, q_std_lit: list[float] = None
+        self,
+        standard: Optional[SAXSStandards] = None,
+        q_std_lit: Optional[List[float]] = None,
     ) -> None:
         """Select standard for calibration of SAXS data from
         `SAXSStandards` enum. If no standard is given, `q_std_lit`
@@ -27,7 +31,7 @@ class PrepareStandard:
 
         Args:
             standard (SAXSStandards, optional): Common SAXS standard used in experiment. Defaults to None.
-            q_std_lit (list[float], optional): Literature values for scattering vector of standard used in experiment. Defaults to None.
+            q_std_lit (List[float], optional): Literature values for scattering vector of standard used in experiment. Defaults to None.
 
         Raises:
             ValueError: If both standard and q_std_lit are provided.
@@ -52,21 +56,21 @@ class PrepareStandard:
             )
 
     def calculate_scattering_vector(
-        self, d_std_lit: list[float] = None
-    ) -> list[float]:
+        self, d_std_lit: Optional[List[float]] = None
+    ) -> List[float]:
         """Calculate scattering vector `q_std_lit` (nm^-1) for
         calibration from literature lattice plane distance `d_std_lit`
         (nm).
 
         Args:
-            d_std_lit (list[float], optional): Lattice plane distance from literature. Defaults to None.
+            d_std_lit (List[float], optional): Lattice plane distance from literature. Defaults to None.
 
         Raises:
             ValueError: If d_std_lit is not given and neither a standard nor q_std_lit have been initialized.
             ValueError: If d_std_lit list is empty.
 
         Returns:
-            list[float]: Scattering vector q_std_lit.
+            List[float]: Scattering vector q_std_lit.
         """
         if self._q_std_lit:
             print(
@@ -83,15 +87,13 @@ class PrepareStandard:
                     "d_std_lit has to be given, as neither a SAXS standard nor q_std_lit have been initialized!"
                 )
             elif len(d_std_lit) < 1:
-                raise ValueError(
-                    f"d_std_lit = {d_std_lit} cannot be an empty list!"
-                )
+                raise ValueError(f"d_std_lit = {d_std_lit} cannot be an empty list!")
 
         self._q_std_lit = [(2 * np.pi) / d for d in d_std_lit]
         return self._q_std_lit
 
     def calculate_linear_regression(
-        self, q_std_meas: list[float]
+        self, q_std_meas: List[float]
     ) -> tuple[float, float]:
         """Calculate the linear regression from `q_std_meas` against
         `q_std_lit` using `numpy.polyfit()` and return `slope` and
@@ -112,7 +114,7 @@ class PrepareStandard:
         return self._standard
 
     @property
-    def q_std_lit(self) -> list[float]:
+    def q_std_lit(self) -> List[float]:
         """Get lscattering vectors of standard from literature used."""
         return self._q_std_lit
 
@@ -131,7 +133,7 @@ class LLCAnalyzer:
         self._d_measured = [(2 * np.pi) / q for q in self.q_corr]
 
     def calibrate_data(
-        self, slope: float, q_meas: list[float], intercept: float
+        self, slope: float, q_meas: List[float], intercept: float
     ) -> None:
         """Calibrate list of measured scattering vectors `q_meas` with
         `(slope, intercept)` tuple from `calculate_linear_regression()`
@@ -140,7 +142,7 @@ class LLCAnalyzer:
 
         Args:
             slope (float): Slope of calculated linear regression from measured standard against literature values.
-            q_meas (list[float]): List of scattering vectors from raw measured data.
+            q_meas (List[float]): List of scattering vectors from raw measured data.
             intercept (float): Intercept of calculated linear regression from measured standard against literature values.
         """
         self._q_corr = [slope * q + intercept for q in q_meas]
@@ -184,16 +186,16 @@ class LLCAnalyzer:
                 return IndeterminatePhase()
 
     @property
-    def q_corr(self) -> list[float]:
+    def q_corr(self) -> List[float]:
         """Get calibrated scattering vectors."""
         return self._q_corr
 
     @property
-    def d_measured(self) -> list[float]:
+    def d_measured(self) -> List[float]:
         """Get lattice plane distances."""
         return self._d_measured
 
     @property
-    def d_ratio(self) -> list[float]:
+    def d_ratio(self) -> List[float]:
         """Get lattice plane ratios."""
         return self._d_ratio

--- a/sastools/readers/originreader.py
+++ b/sastools/readers/originreader.py
@@ -1,15 +1,17 @@
 """Reader for Origin TXT output files containing Lorentzian data."""
 
 import os
-from pathlib import Path
-
 import pandas as pd
+
+from pathlib import Path
+from typing import Union
+
 
 
 class OriginReader:
     """Read Lorentzian data from Origin TXT file."""
 
-    def __init__(self, file: str | bytes | os.PathLike) -> None:
+    def __init__(self, file: Union[str, bytes, os.PathLike]) -> None:
         """Pass path to TXT file with Origin output.
 
         Args:

--- a/sastools/readers/pdhreader.py
+++ b/sastools/readers/pdhreader.py
@@ -2,18 +2,19 @@
 
 
 import os
-from pathlib import Path
 import re
 import tempfile
-
 import pandas as pd
+
 from lxml import etree
+from typing import Union, List
+from pathlib import Path
 
 
 class PDHReader:
     """Separate data block and XML metadata footer of PDH files."""
 
-    def __init__(self, path_to_directory: str | bytes | os.PathLike):
+    def __init__(self, path_to_directory: Union[str, bytes, os.PathLike]):
         """Pass the path to a directory containing PDH-type files to be
         read.
 
@@ -21,16 +22,14 @@ class PDHReader:
             path_to_directory (str | bytes | os.PathLike): Path to a directory containing PDH-type files.
         """
         path = list(Path(path_to_directory).glob("*.pdh"))
-        self._available_files = {
-            file.stem: file for file in path if file.is_file()
-        }
+        self._available_files = {file.stem: file for file in path if file.is_file()}
 
     def __repr__(self):
         return "PDH Reader"
 
     def _line_is_xml(self, line_in_file):
         # Match n whitespaces, followed by an XML opening tag `<`.
-        any_whitespace = re.compile("\s*<").match(line_in_file)
+        any_whitespace = re.compile(r"\s*<").match(line_in_file)
         return any_whitespace
 
     def enumerate_available_files(self) -> dict[int, str]:
@@ -40,9 +39,7 @@ class PDHReader:
         Returns:
             dict[int, str]: Indices and names of available files.
         """
-        return {
-            count: value for count, value in enumerate(self.available_files)
-        }
+        return {count: value for count, value in enumerate(self.available_files)}
 
     def extract_data(self, filestem: str) -> pd.DataFrame:
         """Extract only data block as a `pandas.DataFrame`.
@@ -64,7 +61,7 @@ class PDHReader:
         )
         return dataframe
 
-    def extract_metadata(self, filestem: str) -> etree.ElementTree:
+    def extract_metadata(self, filestem: str) -> etree._ElementTree:
         """Extract XML metadata footer as an `etree.ElementTree`.
 
         Args:
@@ -83,6 +80,6 @@ class PDHReader:
         return XML_tree
 
     @property
-    def available_files(self) -> list[str]:
+    def available_files(self) -> List[str]:
         """Get file available in directory."""
         return self._available_files

--- a/sastools/readers/pdhreader.py
+++ b/sastools/readers/pdhreader.py
@@ -7,7 +7,7 @@ import tempfile
 import pandas as pd
 
 from lxml import etree
-from typing import Union, List
+from typing import Union, List, Dict
 from pathlib import Path
 
 
@@ -32,12 +32,12 @@ class PDHReader:
         any_whitespace = re.compile(r"\s*<").match(line_in_file)
         return any_whitespace
 
-    def enumerate_available_files(self) -> dict[int, str]:
+    def enumerate_available_files(self) -> Dict[int, str]:
         """Enumerate the PDH files available in the given directory and
         return a dictionary with their index and name.
 
         Returns:
-            dict[int, str]: Indices and names of available files.
+            Dict[int, str]: Indices and names of available files.
         """
         return {count: value for count, value in enumerate(self.available_files)}
 

--- a/sastools/readers/seriesreader.py
+++ b/sastools/readers/seriesreader.py
@@ -53,8 +53,6 @@ class SeriesReader:
             )
         )
 
-        # Grab the values from
-
         return pd.DataFrame(
             {
                 series.id: pd.Series(self._get_series_data(series).data)

--- a/sastools/readers/seriesreader.py
+++ b/sastools/readers/seriesreader.py
@@ -24,6 +24,8 @@ class SeriesReader:
         self._animl_doc = animl_doc
         self._available_seriesIDs = self._parse_available_seriesIDs()
         self._selected_seriesIDs = []
+        
+        print(self._available_seriesIDs)
 
     def __repr__(self):
         return "AnIML Series-element Reader"
@@ -31,7 +33,8 @@ class SeriesReader:
     def _parse_available_seriesIDs(self) -> List[str]:
         """Parse AnIMLDocument object and return the seriesID attribute from every Series element within the document."""
         return [
-            series.id for series in self.traverse_model_by_type(self._animl_doc, Series)
+            series.id.rstrip("__")
+            for series in self.traverse_model_by_type(self._animl_doc, Series)
         ]
 
     def create_dataframe(self) -> pd.DataFrame:
@@ -45,7 +48,7 @@ class SeriesReader:
         # Get all series that comply to the IDs
         selected_series = list(
             filter(
-                lambda series: series.id in self.selected_seriesIDs,
+                lambda series: series.id.rstrip("__") in self.selected_seriesIDs,
                 self.traverse_model_by_type(self._animl_doc, Series),
             )
         )

--- a/sastools/readers/seriesreader.py
+++ b/sastools/readers/seriesreader.py
@@ -5,6 +5,7 @@ seriesID attribute and create Pandas DataFrames from them.
 import pandas as pd
 
 from pyaniml import AnIMLDocument
+from typing import List
 
 
 class SeriesReader:
@@ -26,7 +27,7 @@ class SeriesReader:
     def __repr__(self):
         return "AnIML Series-element Reader"
 
-    def _parse_available_seriesIDs(self) -> list[str]:
+    def _parse_available_seriesIDs(self) -> List[str]:
         # Parse AnIMLDocument object and return the seriesID attribute
         # from every Series element within the document.
         available_seriesIDs = []
@@ -72,18 +73,14 @@ class SeriesReader:
         """
         dict_of_data = {}
         for sample_id in self._selected_seriesIDs:
-            experiment_steps = (
-                self._animl_doc.experiment_step_set.experiment_steps
-            )
+            experiment_steps = self._animl_doc.experiment_step_set.experiment_steps
             for experiment_step in experiment_steps:
                 results = experiment_step.result.results
                 for result in results:
                     # check Series in Result
                     try:
                         if sample_id in result.id:
-                            dict_of_data[
-                                result.id
-                            ] = result.individual_value_set.data
+                            dict_of_data[result.id] = result.individual_value_set.data
                     except:
                         pass
                     # check Series in Result.SeriesSet
@@ -123,17 +120,17 @@ class SeriesReader:
         )
 
     @property
-    def available_seriesIDs(self) -> list[str]:
+    def available_seriesIDs(self) -> List[str]:
         """Get SeriesID elements available in the AnIML document."""
         self._available_seriesIDs = self._parse_available_seriesIDs()
         return self._available_seriesIDs
 
     @property
-    def selected_seriesIDs(self) -> list[str]:
+    def selected_seriesIDs(self) -> List[str]:
         """Get list of seriesID selected so far."""
         return self._selected_seriesIDs
 
     @selected_seriesIDs.setter
-    def selected_seriesIDs(self, list_of_ids: list[str]) -> None:
+    def selected_seriesIDs(self, list_of_ids: List[str]) -> None:
         for series_id in list_of_ids:
             self._selected_seriesIDs.append(series_id)

--- a/tests/test_pdhreader.py
+++ b/tests/test_pdhreader.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import pytest
+import re
 
 from lxml import etree
 import pandas as pd
@@ -20,7 +21,14 @@ def test_pdh_reader_repr(pdh_reader):
 
 def test_pdh_reader_enumerate_available_files(pdh_reader):
     available_files = pdh_reader.enumerate_available_files()
-    assert available_files == {0: "pdh_test_1", 1: "pdh_test_0"}
+
+    FILE_PATTERN = r"pdh_test_[\d]*"
+    matches = lambda fname: bool(re.match(FILE_PATTERN, fname))
+
+    assert len(available_files) == 2, f"Expected 2 files, got {len(available_files)}"
+    assert all(
+        matches(name) for name in available_files.values()
+    ), f"File names have changed, got {available_files.values()}"
 
 
 def test_pdh_reader_extract_data(pdh_reader):

--- a/tests/test_seriesreader.py
+++ b/tests/test_seriesreader.py
@@ -6,7 +6,7 @@ from pyaniml import AnIMLDocument
 
 from sastools.readers import SeriesReader
 
-TEST_ID = ["x0", "y0"]
+TEST_ID = ["x0__", "y0__"]
 
 
 @pytest.fixture

--- a/tests/test_seriesreader.py
+++ b/tests/test_seriesreader.py
@@ -6,7 +6,7 @@ from pyaniml import AnIMLDocument
 
 from sastools.readers import SeriesReader
 
-TEST_ID = ["x0__", "y0__"]
+TEST_ID = ["x0", "y0"]
 
 
 @pytest.fixture


### PR DESCRIPTION
The following Pull Request introduces the following changes:

- Added GitHub workflow to run tests on push --> Tests for 3.7/8/9/10 now
- Refactored type hints to comply with older versions using the ```typing``` module
- Fixed issue with ```xsData``` behaving different in older Python versions (3.7, 3.9) in ```SeriesReader```